### PR TITLE
Empty memory

### DIFF
--- a/src/cpr/Resource.py
+++ b/src/cpr/Resource.py
@@ -46,8 +46,14 @@ class Resource(ABC):
         name, ext = splitext(file_name)
         return cls(location=location, name=name, ext=ext)
 
-    def get_data(self):
+    def get_data(self, cache=False):
         """Access the data."""
+        if cache:
+            self._data = self._read_data()
+        else:
+            return self._read_data()
+
+    def _read_data(self):
         ...
 
     def get_name(self) -> str:

--- a/src/cpr/Target.py
+++ b/src/cpr/Target.py
@@ -1,3 +1,4 @@
+import gc
 from os.path import join
 
 from cpr.Resource import Resource
@@ -55,6 +56,9 @@ class Target(Resource):
         """Persist data and serialize to JSON serializable dict."""
         self.compute_data_hash()
         self._write_data()
+        del self._data
+        gc.collect()
+        self._data = None
         d = super(Target, self).serialize()
         d["data_hash"] = self.data_hash
         return d

--- a/src/cpr/csv/CSVSource.py
+++ b/src/cpr/csv/CSVSource.py
@@ -1,5 +1,3 @@
-from os.path import exists
-
 import pandas as pd
 
 from cpr.Resource import Resource
@@ -31,18 +29,5 @@ class CSVSource(Resource):
             ext=ext,
         )
 
-    def get_data(self):
-        """Access DataFrame.
-
-        The DataFrame is cached by this call.
-
-        Returns
-        -------
-        DataFrame
-        """
-        if self._data is None:
-            assert exists(self.get_path()), f"{self.get_path()} does not " f"exist."
-
-            self._data = pd.read_csv(self.get_path())
-
-        return self._data
+    def _read_data(self):
+        return pd.read_csv(self.get_path(), index_col=0)

--- a/src/cpr/csv/CSVTarget.py
+++ b/src/cpr/csv/CSVTarget.py
@@ -49,25 +49,13 @@ class CSVTarget(Target):
             data_hash=data_hash,
         )
 
-    def get_data(self) -> pd.DataFrame:
-        """Access DataFrame.
-
-        The DataFrame is cached by this call.
-
-        Returns
-        -------
-        DataFrame
-        """
-        if self._data is None:
-            assert exists(self.get_path()), f"{self.get_path()} does not " f"exist."
-
-            self._data = pd.read_csv(self.get_path(), index_col=0)
-            assert self._hash_data(self._data) == self.data_hash, (
-                "Loaded csv has a different hash. This data is either "
-                "from a different run or corrupted."
-            )
-
-        return self._data
+    def _read_data(self):
+        data = pd.read_csv(self.get_path(), index_col=0)
+        assert self._hash_data(data) == self.data_hash, (
+            "Loaded csv has a different hash. This data is either "
+            "from a different run or corrupted."
+        )
+        return data
 
     def _hash_data(self, a):
         return xxhash.xxh3_64(hash_pandas_object(a).values.tobytes()).hexdigest()

--- a/src/cpr/image/ImageSource.py
+++ b/src/cpr/image/ImageSource.py
@@ -1,4 +1,3 @@
-from os.path import exists
 from typing import Any, Dict, List
 
 from numpy._typing import ArrayLike
@@ -91,22 +90,8 @@ class ImageSource(Resource, Metadata):
         img.resolution = resolution
         return img
 
-    def get_data(self) -> ArrayLike:
-        """Access image data.
-
-        The image data is cached by this function.
-
-        Returns
-        -------
-        Image data as numpy array
-        """
-
-        if self._data is None:
-            assert exists(self.get_path()), f"{self.get_path()} does not " f"exist."
-
-            self._data = imread(self.get_path())
-
-        return self._data
+    def _read_data(self) -> ArrayLike:
+        return imread(self.get_path())
 
     def serialize(self) -> Dict:
         """Serialize to JSON serializable dict."""

--- a/src/cpr/image/ImageTarget.py
+++ b/src/cpr/image/ImageTarget.py
@@ -135,26 +135,13 @@ class ImageTarget(Target, Metadata):
 
         self.resolution = resolution
 
-    def get_data(self) -> ArrayLike:
-        """Access image data.
-
-        The image data is cached by this function.
-
-        Returns
-        -------
-        Image data as numpy array
-        """
-
-        if self._data is None:
-            assert exists(self.get_path()), f"{self.get_path()} does not " f"exist."
-
-            self._data = imread(self.get_path())
-            assert self._hash_data(self._data) == self.data_hash, (
-                "Loaded image has a different hash. This data is either "
-                "from a different run or corrupted."
-            )
-
-        return self._data
+    def _read_data(self) -> ArrayLike:
+        data = imread(self.get_path())
+        assert self._hash_data(data) == self.data_hash, (
+            "Loaded image has a different hash. This data is either "
+            "from a different run or corrupted."
+        )
+        return data
 
     def _hash_data(self, a):
         data = bytes()

--- a/src/cpr/numpy/NumpySource.py
+++ b/src/cpr/numpy/NumpySource.py
@@ -1,7 +1,4 @@
-from os.path import exists
-
 import numpy as np
-from numpy._typing import ArrayLike
 
 from cpr.Resource import Resource
 
@@ -27,19 +24,5 @@ class NumpySource(Resource):
             ext=ext,
         )
 
-    def get_data(self) -> ArrayLike:
-        """Access numpy array data.
-
-        The data is cached by this function.
-
-        Returns
-        -------
-        Array data
-        """
-
-        if self._data is None:
-            assert exists(self.get_path()), f"{self.get_path()} does not exist."
-
-            self._data = np.load(self.get_path())
-
-        return self._data
+    def _read_data(self):
+        return np.load(self.get_path())

--- a/src/cpr/numpy/NumpyTarget.py
+++ b/src/cpr/numpy/NumpyTarget.py
@@ -2,7 +2,6 @@ from os.path import exists
 
 import numpy as np
 import xxhash
-from numpy._typing import ArrayLike
 
 from cpr.Target import Target
 
@@ -46,25 +45,13 @@ class NumpyTarget(Target):
             data_hash=data_hash,
         )
 
-    def get_data(self) -> ArrayLike:
-        """Access numpy array data.
-
-        The data is cached by this function.
-
-        Returns
-        -------
-        Array data.
-        """
-        if self._data is None:
-            assert exists(self.get_path()), f"{self.get_path()} does not " f"exist."
-
-            self._data = np.load(self.get_path())
-            assert self._hash_data(self._data) == self.data_hash, (
-                "Loaded data has a different hash. This data is either "
-                "from a different run or corrupted."
-            )
-
-        return self._data
+    def _read_data(self):
+        data = np.load(self.get_path())
+        assert self._hash_data(data) == self.data_hash, (
+            "Loaded data has a different hash. This data is either "
+            "from a different run or corrupted."
+        )
+        return data
 
     def _hash_data(self, a) -> str:
         data = bytes()

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -48,7 +48,7 @@ class CSVTest(TestCase):
 
     def test_csv_source(self):
         path = join(self.tmp_dir, "source_table.csv")
-        self.data.to_csv(path, index=False)
+        self.data.to_csv(path, index=True)
 
         csv = CSVSource.from_path(path)
 


### PR DESCRIPTION
This fixes a "memory leak" with custom results. Once a result is serialized the `_data` attributed is cleared and the garbage collector is called. The second change makes the caching on `get_data()` optional. Otherwise it is complicated to free the loaded data from a result if it is used as an input to a task (hidden file reference).